### PR TITLE
Beautify the code html instead of its text

### DIFF
--- a/beautifier.js
+++ b/beautifier.js
@@ -2,7 +2,7 @@ if (document.body.childNodes.length === 1 &&
   document.body.children[0].nodeName === 'PRE' &&
   document.body.children[0].children.length === 0 &&
   document.head.children.length === 1 &&
-  ddocument.head.children[0].rel === "stylesheet") {
+  document.head.children[0].rel === "stylesheet") {
 
   var pre = document.getElementsByTagName('pre')[0];
   js_code = pre.innerText;

--- a/beautifier.js
+++ b/beautifier.js
@@ -1,10 +1,15 @@
-var pre = document.getElementsByTagName('pre')[0];
-js_code = pre.innerText;
-pre.innerText = "";
-var code = document.createElement("code");
-code.classList.add("javascript");
-pre.appendChild(code)
-var source_code = js_beautify(js_code);
-code.innerHTML = source_code;
-hljs.highlightBlock(code);
-document.body.style.backgroundColor = window.getComputedStyle(code).backgroundColor
+if (document.body.childNodes.length === 1 &&
+	document.body.children[0].nodeName === 'PRE') {
+
+  var pre = document.getElementsByTagName('pre')[0];
+  js_code = pre.innerText;
+  pre.innerText = "";
+  var code = document.createElement("code");
+  code.classList.add("javascript");
+  pre.appendChild(code)
+  var source_code = js_beautify(js_code);
+  code.innerHTML = source_code;
+  hljs.highlightBlock(code);
+  document.body.style.backgroundColor = window.getComputedStyle(code).backgroundColor
+
+}

--- a/beautifier.js
+++ b/beautifier.js
@@ -1,5 +1,8 @@
 if (document.body.childNodes.length === 1 &&
-	document.body.children[0].nodeName === 'PRE') {
+  document.body.children[0].nodeName === 'PRE' &&
+  document.body.children[0].children.length === 0 &&
+  document.head.children.length === 1 &&
+  ddocument.head.children[0].rel === "stylesheet") {
 
   var pre = document.getElementsByTagName('pre')[0];
   js_code = pre.innerText;

--- a/beautifier.js
+++ b/beautifier.js
@@ -5,7 +5,6 @@ var code = document.createElement("code");
 code.classList.add("javascript");
 pre.appendChild(code)
 var source_code = js_beautify(js_code);
-code.innerText = source_code;
-hljs.configure({useBR: true});
+code.innerHTML = source_code;
 hljs.highlightBlock(code);
 document.body.style.backgroundColor = window.getComputedStyle(code).backgroundColor


### PR DESCRIPTION
That solves the issue of having too much <br> at the html of code.
Besides that, it mantains the improvement of avoiding commeting
out the whole code after a single line comment.

Resolves: #4
See #1